### PR TITLE
fix: pre-0.9.0 defect sweep, drift guard, and CHANGELOG promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,20 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: python3 tapestry/tapestry-os/tools/gen_wire_protocol.py --check
 
+      # Same guarantee for Choreo scripts: every committed choreo_script.h
+      # must match what its .choreo.toml generates today.  These headers are
+      # committed so firmware builds never need Python, which also means a
+      # script edit that isn't recompiled ships silently — and one already
+      # did: examples/webots-formation's copy sat a release behind
+      # examples/cf21bl-formation's, so the simulation ran a different
+      # script than the hardware demo it claimed to mirror.  No arguments:
+      # choreoc discovers every generated header and recovers its source
+      # from its own banner, so a new example is covered without touching
+      # this file.
+      - name: Check Choreo script headers are up to date
+        working-directory: ${{ github.workspace }}
+        run: python3 tapestry/sdk/tools/choreoc.py --check
+
       # Sets up a west workspace at $GITHUB_WORKSPACE, installs the
       # Zephyr SDK, and exports ZEPHYR_BASE.  The app-path tells the
       # action where the west.yml manifest lives.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-08-16
+
 ### Added
 - **Real L5 SCR wired into `examples/cf21bl-formation` and
   `examples/webots-formation`'s cf21bl controller** — both now call
-  `scr_init()`/`scr_tick()` (quorum, role, task_slot, abort protocol)
-  instead of synthesizing a quorum signal from raw L4 freshness;
-  `SUSPENDED` is now triggered by the actual L5 quorum computation in
-  both. Enforced real-world geofence and mission-duration landing backstops.
+  `scr_init()`/`scr_tick()`, so role, `task_slot`, leader election and the
+  abort protocol are computed from the actual world model instead of being
+  synthesized from raw L4 freshness. Note that `SUSPENDED` is additionally
+  gated by an application-level debounce: both apps overwrite
+  `scr_state_t::quorum_state` after `scr_tick()` with a sustained-freshness signal (`QUORUM_UP_MS`, 2 s) before handing it to `choreo_tick()`. At the thresholds both apps configure (`quorum_min` = `quorum_target` = 1) this yields the same HEALTHY/LOST verdict L5 computes, plus a 2 s confirmation before an up-transition is believed — quorum loss is still immediate. The debounce is applied to a copy handed to `choreo_tick()`, never written back into the live `scr_state_t`, so L5's own accessors stay mutually consistent. Hysteresis on quorum acquisition belongs inside L5 rather than being repeated per application — deciding whether the collective has quorum is L5's responsibility, and an obligation carried by every element main loop is one every new element main loop can forget (TODO). Enforced real-world geofence and mission-duration landing backstops.
 - **Collective achievement (`scope = "all"`)** — each element now gossips
   an `achieved` bit every cycle (`tapestry_gossip_frame_t` gains an
   `achieved` field, a wire-compatible append — no `TAPESTRY_WIRE_VERSION`
@@ -38,10 +41,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   or network involved. For someone editing a script who has no build 
   toolchain or Webots set up yet, or is designing for a substrate 
   that doesn't exist as code
+- **`choreoc.py --check`, enforced in CI** — generated `choreo_script.h`
+  headers are committed so firmware builds never need Python, which means
+  a script edit that is not recompiled ships silently. `--check` writes
+  nothing and exits non-zero if a committed header does not match what its
+  script generates today, the same guarantee
+  `gen_wire_protocol.py --check` already gave the wire mirrors. With no
+  arguments it discovers every generated header in the repository and
+  recovers each one's source from the regenerate command line in its own
+  banner, so an added consumer is covered without editing CI — the drift
+  it is meant to catch happened precisely because a second consumer was
+  added and nothing knew to keep it in sync
 
 ### Changed
-- **`sdk/README.md`, `choreo.h`, `bse.h`, `bse.c`, `choreo.c`, and their
-  Python mirrors** now achieved v1.0 feature-scope 
+- **Status banners rewritten across `sdk/README.md`, `choreo.h`, `bse.h`,
+  `bse.c`, `choreo.c` and their Python mirrors** — feature ready for v1.0 release. They now itemize the feature scope: what L6/L7
+  implement today, and which capabilities (physics planner, ML runtime,
+  goal queue with preemption and arbitration, hi-fi simulation bridge,
+  monitor telemetry export) are deliberately out of scope rather than
+  merely unfinished
 
 ### Fixed
 - **`FORM` shape** — `shape = "line"` and `"grid"` were accepted and
@@ -54,6 +72,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `CONVERGE`, correctly, since there is no formation to preserve
 - **`tapestry-scr-hw`'s movement loop** — `substrate_move()` is now
   directive-driven reading `choreo_get_directive()`
+- **`examples/webots-formation` ran a stale Choreo script** — its generated
+  `choreo_script.h` predated collective achievement and was missing
+  `scope = "all"` on the exchange step, so the simulation did not run the
+  same script as the hardware demo despite the README saying it did.
+  Regenerated from `change-partners.choreo.toml`
+- **Out-of-range element ID corrupted memory in L4/L5** — `wm_init()` and
+  `wm_update_self()` indexed `world_model_t::entries[]` with an unvalidated
+  `owner_id` (an out-of-bounds *write* for any ID ≥ `MAX_ELEMENTS`),
+  `wm_check_collisions()` read the same way, and `scr_tick()` could write
+  one entry past its `candidates[]` array because its peer loop skips only
+  `own_id`. Peer IDs arriving over the wire were already validated; the
+  owner's ID, which comes from the application, was not. It is now checked
+  once in `wm_init()` — an out-of-range owner leaves the model inert rather
+  than corrupting adjacent memory — and `scr_tick()`'s array is sized for
+  the worst case. Reachable through a hand-configured element ID or an
+  `ELEMENT_ID_INVALID` propagated from a failed identity negotiation
+- **`transport.h` contradicted `wire.h` on QoS** — `transport_send()`'s
+  documentation claimed `qos_tier` was "embedded in the gossip frame so
+  peers can prioritize accordingly". It is not: `gossip_send()` ignores the
+  parameter, and `wire.h` correctly documents the tiers as reserved
+  placeholders. `transport.h` now says the same
 
 ## [0.8.0] — 2026-08-01
 
@@ -235,8 +274,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   for all three hardware targets and Phase 2 firmware
 - `CODE_OF_CONDUCT.md`, `SECURITY.md`
 
-[Unreleased]: https://github.com/tapestry-os/tapestry/compare/v0.8.0...HEAD
-[0.8.0]: https://github.com/tapestry-os/tapestry/compare/v0.7.0...v0.8.0
+[Unreleased]: https://github.com/tapestry-os/tapestry/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/tapestry-os/tapestry/compare/v0.8.0...v0.9.0[0.8.0]: https://github.com/tapestry-os/tapestry/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/tapestry-os/tapestry/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/tapestry-os/tapestry/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/tapestry-os/tapestry/compare/v0.5.0...v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   added and nothing knew to keep it in sync
 
 ### Changed
+- **L6/L7 interface prepared for a queueing implementation** — no behavior
+  change; three adjustments so a prioritised-goal-queue BSE can drop in
+  behind the same headers without a breaking release. (1)
+  `bse_submit_intent()` documented that the *displaced* intent's fate is
+  implementation-defined; it previously promised the achievement predicate
+  and every activation capture would be reset, which a preempting
+  implementation must not do. The reference implementation still discards,
+  as before. (2) The state an intent accumulates while active — achievement
+  progress, HOLD station, EXCHANGE snapshot and arc progress, MOVE centroid
+  offset — is now grouped as `bse_activation_t` in `bse.c` rather than
+  fourteen loose statics, since that is exactly what a preempting engine has
+  to stack; tick-scoped values are deliberately left outside it. (3)
+  `choreo_goal_t` and `tapestry_bse_intent_t` gain a caller-assigned
+  `id` (0 = anonymous, opaque to Tapestry, unread by this implementation),
+  so per-goal cancel and preemption reporting can be added later without
+  changing `choreo_submit_goal()`'s return convention — every one of its
+  call sites tests it against 0 today. Also documented that a preempted
+  goal reports as `SUSPENDED` rather than a new lifecycle state, so
+  `choreo_state_t` need never grow a member and break existing switches
 - **Status banners rewritten across `sdk/README.md`, `choreo.h`, `bse.h`,
   `bse.c`, `choreo.c` and their Python mirrors** — feature ready for v1.0 release. They now itemize the feature scope: what L6/L7
   implement today, and which capabilities (physics planner, ML runtime,

--- a/examples/cf21bl-formation/src/main.c
+++ b/examples/cf21bl-formation/src/main.c
@@ -676,10 +676,27 @@ int main(void)
              * (possibly corrupt) position estimate (2026-07-19 flight 2).
              * Requiring ≥ QUORUM_UP_MS of SUSTAINED freshness means at
              * least two consecutive gossip frames: real contact, not a
-             * lucky packet.  Loss is immediate.  Only quorum_state — the
-             * one field choreo_tick() reads — is overridden below; scr's
-             * own role/task_slot/abort bookkeeping keeps tracking the
-             * real, undebounced quorum history. */
+             * lucky packet.  Loss is immediate.  At this example's
+             * thresholds (quorum_min = quorum_target = 1) that is the same
+             * verdict scr_tick() computes, plus a confirmation delay on the
+             * up-transition that peer counts cannot express.
+             *
+             * The debounce is applied to a COPY handed to choreo_tick(),
+             * never written back into scr: quorum_state is the only field
+             * L6/L7 reads, and mutating the live struct would leave
+             * scr_get_quorum() reporting the debounced view while
+             * _prev_quorum_state and scr_get_abort_state() tracked the real
+             * history — a state the L5 contract says cannot happen, and a
+             * trap for whoever wires in the abort protocol.
+             *
+             * This debounce belongs inside L5, not here: deciding whether
+             * the collective has quorum is L5's job, and an obligation
+             * every element main loop has to remember is one a new element
+             * main loop will forget.  It lives here only because moving it
+             * makes scr_tick() time-dependent (today it is a pure function
+             * of the world model) and delays SCR_ABORT_CLEARED by
+             * QUORUM_UP_MS — a change to the L5→L6 contract that wants
+             * flight validation, not a refactor.  Deferred past 0.9.0. */
 #define QUORUM_UP_MS 2000
             float nearest_m = -1.0f;
             for (int i = 0; i < MAX_ELEMENTS; i++) {
@@ -703,8 +720,9 @@ int main(void)
             }
             bool quorum_up = fresh_streak_ms >= QUORUM_UP_MS;
             log_quorum_up = quorum_up;
-            scr.quorum_state = quorum_up ? SCR_QUORUM_HEALTHY
-                                         : SCR_QUORUM_LOST;
+            scr_state_t scr_view = scr;
+            scr_view.quorum_state = quorum_up ? SCR_QUORUM_HEALTHY
+                                              : SCR_QUORUM_LOST;
 
             /* Station-compatibility check, once per contact: stations
              * closer than ~2× the separation floor mean station-keeping
@@ -724,7 +742,7 @@ int main(void)
             }
             was_up = quorum_up;
 
-            choreo_tick(&wm, &scr);
+            choreo_tick(&wm, &scr_view);
             own_state.goal_achieved = choreo_goal_achieved();
 
             static int last_step = -2;

--- a/examples/webots-formation/controllers/cf21bl/choreo_script.h
+++ b/examples/webots-formation/controllers/cf21bl/choreo_script.h
@@ -31,7 +31,7 @@ static const choreo_step_t k_choreo_script[CHOREO_SCRIPT_LEN] = {
                 .achieve_eps = 0.25f,
                 .achieve_hold_ms = 3000u },
       .max_duration_ms = 30000u,
-      .advance_on_achieved = true },
+      .advance_on_achieved = true, .scope = CHOREO_SCOPE_ALL },
 
     { .goal = { .type = CHOREO_GOAL_HOLD,
                 .required_caps = CHOREO_CAP_LOCOMOTION },

--- a/examples/webots-formation/controllers/cf21bl/main.c
+++ b/examples/webots-formation/controllers/cf21bl/main.c
@@ -241,10 +241,11 @@ int main(int argc, char **argv)
 
             /* Real L5: recompute quorum/role/task_slot/abort from the
              * actual world model, then apply the SUSTAINED-freshness
-             * debounce on top — see QUORUM_UP_MS above. Only quorum_state
-             * (the field choreo_tick() reads) is overridden; scr's own
-             * role/task_slot/abort bookkeeping keeps tracking the real,
-             * undebounced quorum history. */
+             * debounce on top — see QUORUM_UP_MS above. The debounce goes
+             * into a COPY handed to L6/L7, never back into scr, so
+             * scr_get_quorum() and scr_get_abort_state() cannot disagree
+             * about quorum history; same rationale as cf21bl-formation's
+             * main.c, which carries the full comment. */
             scr_tick(&scr, &wm);
             if (scr.fresh_count >= 1) {
                 if (fresh_streak_ms < QUORUM_UP_MS) {
@@ -255,14 +256,18 @@ int main(int argc, char **argv)
             }
             bool quorum_up = fresh_streak_ms >= QUORUM_UP_MS;
             log_quorum_up = quorum_up;
-            scr.quorum_state = quorum_up ? SCR_QUORUM_HEALTHY : SCR_QUORUM_LOST;
+            scr_state_t scr_view = scr;
+            scr_view.quorum_state = quorum_up ? SCR_QUORUM_HEALTHY : SCR_QUORUM_LOST;
 
-            choreo_tick(&wm, &scr);
+            choreo_tick(&wm, &scr_view);
 
+            /* Capture the VIEW, not scr: the replay harness re-drives the
+             * Python engine against exactly what choreo_tick() saw, so the
+             * recorded quorum_state has to be the debounced one. */
             const tapestry_bse_directive_t *dir = choreo_get_directive();
             choreo_telemetry_write(telemetry, telemetry_tick,
                                    (double)telemetry_tick * WM_CYCLE_MS / 1000.0,
-                                   &wm, &scr, dir);
+                                   &wm, &scr_view, dir);
             telemetry_tick++;
 
             if (choreo_script_step() != last_step) {
@@ -356,6 +361,16 @@ int main(int argc, char **argv)
         if (gossip_accum_ms >= DEMO_GOSSIP_MS) {
             gossip_accum_ms = 0;
             own_state.update_seq++;
+            /* Publish this element's own-goal achievement so peers can
+             * aggregate the scope="all" collective predicate
+             * (choreo_collective_achieved()). Refreshed here, at the send,
+             * rather than beside choreo_tick(): this loop keeps gossiping
+             * after landing (see above), and a landed element must report
+             * the achievement state it actually finished on, not the one it
+             * held on its last airborne tick. Every element main loop that
+             * gossips has to do this — without it the bit is permanently 0
+             * and a scope="all" step can never advance on achievement. */
+            own_state.goal_achieved = choreo_goal_achieved();
             gossip_send(&own_state, TAPESTRY_QOS_SOFT_RT);
         }
     }

--- a/sdk/CHOREO_SCRIPTS.md
+++ b/sdk/CHOREO_SCRIPTS.md
@@ -303,11 +303,31 @@ reference (`--elements`, `--speed`, `--plot`, `--out`).
 1. Edit `<name>.choreo.toml`.
 2. `python3 sdk/tools/choreoc.py <name>.choreo.toml` (or with `-o` if not
    using the default output path).
-3. Rebuild the firmware. Commit both the `.toml` and the regenerated
-   header — CI/other builders never run `choreoc` themselves.
+3. **Regenerate every consumer.** One script can be compiled into more
+   than one header — `change-partners.choreo.toml` feeds both
+   `examples/cf21bl-formation/src/` and
+   `examples/webots-formation/controllers/cf21bl/` — and each needs its
+   own `-o` run. Miss one and that consumer silently keeps running the
+   previous version of the show; this has happened.
+4. Rebuild the firmware. Commit both the `.toml` and the regenerated
+   headers — CI/other builders never run `choreoc` themselves.
+
+To find out what is stale without regenerating anything:
+
+```bash
+python3 sdk/tools/choreoc.py --check
+```
+
+With no arguments this checks every generated header in the repository,
+recovering each one's source script from the regenerate command line in
+its own banner, and exits non-zero if any differs from what its script
+generates today. CI runs exactly this, so a missed step 3 fails the build
+instead of reaching a drone. Add `<script> -o <header>` to check a single
+pair.
 
 The Python side needs no rebuild step; it reads the `.toml` directly on
-every run.
+every run — which is also why a stale header shows up as the C and Python
+engines disagreeing in a replay diff.
 
 ## See also
 

--- a/sdk/include/tapestry/choreo.h
+++ b/sdk/include/tapestry/choreo.h
@@ -63,6 +63,18 @@
  *               suspended (station capture and station-keeping need no
  *               peers); PEER-referential goals (EXCHANGE) are frozen.
  *               Resumes automatically to RUNNING when quorum recovers.
+ *
+ *               SUSPENDED is deliberately defined as "paused, preserved,
+ *               resumes automatically" rather than as "quorum lost".  An
+ *               implementation with a prioritised goal queue reports a
+ *               preempted goal as SUSPENDED too: the semantics are the
+ *               same from the application's side, only the cause differs.
+ *               This enum is therefore not expected to grow a PREEMPTED
+ *               member — adding one would break exhaustive switches in
+ *               existing applications for no gain.  A caller that needs to
+ *               distinguish the causes should read the goal's identity
+ *               (choreo_goal_t::id) and the monitor/telemetry path, not
+ *               the lifecycle state.
  *   TERMINATED  choreo_terminate() called; goal cleared.  Transitions
  *               immediately back to IDLE — callers polling goal_status()
  *               will see IDLE, not TERMINATED, in steady-state.
@@ -148,6 +160,23 @@ typedef struct {
                                             (see bse.h; arc is the default)      */
     float                 achieve_eps;   /* achievement radius (0 → BSE default)  */
     uint32_t              achieve_hold_ms; /* sustain time (0 → BSE default)      */
+
+    /*
+     * Caller-assigned goal identity.  Opaque to Tapestry: the SDK never
+     * generates, interprets, or requires it, and 0 means "anonymous" —
+     * the behavior of every goal written before this field existed.
+     *
+     * It exists so that goal identity does not have to be retrofitted onto
+     * choreo_submit_goal()'s return value later.  This implementation runs
+     * one goal at a time, so an application can always say "the current
+     * goal"; an implementation with a prioritised goal queue cannot, and
+     * needs a way for callers to name which goal to cancel, and a way to
+     * report which goal preempted which.  Assigning that name here keeps
+     * both additive: no existing signature changes, and no call site has
+     * to be touched.  Carried through to tapestry_bse_intent_t::id so L6
+     * can attribute a directive to the goal that produced it.
+     */
+    uint16_t              id;
 } choreo_goal_t;
 
 /* ── Script: an ordered sequence of goals (minimal Choreo container) ─────── */

--- a/sdk/python/tapestry/bse.py
+++ b/sdk/python/tapestry/bse.py
@@ -102,6 +102,8 @@ class BSEIntent:
     direct_path: bool = False      # EXCHANGE beeline vs centroid arc
     achieve_eps: float = 0.0       # 0 → ACHIEVE_EPS_DEFAULT
     achieve_hold_ms: int = 0       # 0 → ACHIEVE_HOLD_MS_DEFAULT
+    id: int = 0                    # originating goal identity; opaque, unread
+                                   # here. Mirrors tapestry_bse_intent_t::id
 
 
 @dataclass

--- a/sdk/python/tapestry/choreo.py
+++ b/sdk/python/tapestry/choreo.py
@@ -104,6 +104,12 @@ class Goal:
     direct_path:     bool = False  # EXCHANGE beeline vs arc (see bse.py)
     achieve_eps:     float = 0.0 # achievement radius (0 → BSE default)
     achieve_hold_ms: int = 0     # sustain time, ms (0 → BSE default)
+    id:              int = 0     # caller-assigned goal identity; 0 = anonymous.
+                                 # Opaque to Tapestry — never generated or
+                                 # interpreted here. Mirrors choreo_goal_t::id;
+                                 # see choreo.h for why it exists (goal identity
+                                 # for queueing/preemption, reserved additively
+                                 # so no signature has to change later).
 
 
 @dataclass
@@ -441,4 +447,5 @@ class Choreo:
             direct_path     = goal.direct_path,
             achieve_eps     = goal.achieve_eps,
             achieve_hold_ms = goal.achieve_hold_ms,
+            id              = goal.id,   # opaque; see Goal.id
         )

--- a/sdk/tools/choreoc.py
+++ b/sdk/tools/choreoc.py
@@ -17,9 +17,19 @@ for choreo = "change-partners") — see sdk/CHOREO_SCRIPTS.md.
 
 Usage:
     python3 sdk/tools/choreoc.py <name.choreo.toml> [-o <out.h>]
+    python3 sdk/tools/choreoc.py --check [<name.choreo.toml> [-o <out.h>]]
 
 With no -o, the header is written next to the script as
 src/choreo_script.h if src/ exists, else choreo_script.h alongside it.
+
+--check writes nothing and exits 1 if a committed header does not match
+what its script would generate today.  With no script argument it checks
+EVERY generated header in the repository, recovering each one's source
+from the regenerate command line embedded in its own banner.  Discovery
+rather than a hardcoded list is deliberate: a script compiled into two
+consumers drifted once already (examples/webots-formation's copy sat a
+release behind examples/cf21bl-formation's), and a list that has to be
+edited by hand when a consumer is added would have missed it the same way.
 
 The Python SDK reads the SAME file directly — no generation step:
     from tapestry.script_toml import load_steps
@@ -27,8 +37,18 @@ The Python SDK reads the SAME file directly — no generation step:
 """
 
 import argparse
+import re
 import sys
 from pathlib import Path
+
+# choreoc.py lives at <workspace>/tapestry/sdk/tools/.  Generated banners
+# spell paths relative to the WORKSPACE root (west's checkout root, the
+# directory holding tapestry/), while discovery scans the repository.
+WORKSPACE_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+REPO_ROOT      = Path(__file__).resolve().parent.parent.parent
+
+# "python3 tapestry/sdk/tools/choreoc.py <script> -o <header>"
+REGEN_RE = re.compile(r"choreoc\.py\s+(\S+)\s+-o\s+(\S+)")
 
 # Import the tapestry package from the sibling sdk/python directory without
 # requiring installation.
@@ -141,38 +161,111 @@ static const choreo_step_t k_choreo_script[CHOREO_SCRIPT_LEN] = {{
 """
 
 
+def default_output(script_path: Path) -> Path:
+    """Where the header lands when -o is omitted."""
+    src_dir = script_path.parent / "src"
+    return (src_dir if src_dir.is_dir() else script_path.parent) \
+        / "choreo_script.h"
+
+
+def render(script_path: Path, out_path: Path) -> tuple[ChoreoScript, str]:
+    """Parse a script and render the header text it should produce at
+    out_path.  The output embeds out_path (in the regenerate banner), so
+    the same script rendered for two consumers differs by that line — which
+    is why check compares against a render targeting the SAME path."""
+    script = parse_file(script_path)
+    try:
+        rel_script = script_path.resolve().relative_to(WORKSPACE_ROOT)
+        rel_out    = out_path.resolve().relative_to(WORKSPACE_ROOT)
+        regen = f"python3 tapestry/sdk/tools/choreoc.py {rel_script} -o {rel_out}"
+    except ValueError:
+        regen = f"python3 choreoc.py {script_path} -o {out_path}"
+    return script, emit_header(script, script_path.name, regen)
+
+
+def discover_pairs() -> list[tuple[Path, Path]]:
+    """Find every committed generated header and recover its source script
+    from the regenerate command line in its own banner.  Returns
+    (script, header) pairs.  Build trees are skipped — they hold copies."""
+    pairs: list[tuple[Path, Path]] = []
+    for header in sorted(REPO_ROOT.rglob("choreo_script.h")):
+        if "build" in header.parts:
+            continue
+        m = REGEN_RE.search(header.read_text())
+        if m is None:
+            print(f"choreoc: {header.relative_to(REPO_ROOT)} — no regenerate "
+                  f"command in banner; cannot determine its source script",
+                  file=sys.stderr)
+            continue
+        script = (WORKSPACE_ROOT / m.group(1)).resolve()
+        if not script.is_file():
+            print(f"choreoc: {header.relative_to(REPO_ROOT)} — banner names "
+                  f"{m.group(1)}, which does not exist", file=sys.stderr)
+            continue
+        pairs.append((script, header))
+    return pairs
+
+
+def check_pair(script_path: Path, out_path: Path) -> bool:
+    """True if out_path already matches what script_path generates."""
+    rel = out_path.resolve()
+    try:
+        rel = rel.relative_to(REPO_ROOT)
+    except ValueError:
+        pass
+    try:
+        _, expected = render(script_path, out_path)
+    except (ScriptError, OSError) as e:
+        print(f"choreoc: {e}", file=sys.stderr)
+        return False
+    if not out_path.is_file():
+        print(f"choreoc: {rel} — MISSING (never generated)", file=sys.stderr)
+        return False
+    if out_path.read_text() != expected:
+        print(f"choreoc: {rel} — STALE (regeneration needed)", file=sys.stderr)
+        return False
+    print(f"choreoc: {rel} — already up to date")
+    return True
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(
         prog="choreoc", description="Compile a Choreo script (TOML) into a "
         "C header of choreo_step_t.")
-    ap.add_argument("script", type=Path, help="path to the .toml script")
+    ap.add_argument("script", type=Path, nargs="?",
+                    help="path to the .toml script (omit with --check to "
+                         "check every generated header in the repository)")
     ap.add_argument("-o", "--output", type=Path, default=None,
                     help="output header path (default: src/choreo_script.h "
                          "next to the script if src/ exists, else "
                          "choreo_script.h)")
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if a committed header does not match what "
+                         "its script generates; write nothing")
     args = ap.parse_args()
 
+    if args.script is None:
+        if not args.check:
+            ap.error("a script is required unless --check is given")
+        pairs = discover_pairs()
+        if not pairs:
+            print("choreoc: no generated headers found", file=sys.stderr)
+            return 1
+        return 0 if all([check_pair(s, h) for s, h in pairs]) else 1
+
+    out = args.output if args.output is not None \
+        else default_output(args.script)
+
+    if args.check:
+        return 0 if check_pair(args.script, out) else 1
+
     try:
-        script = parse_file(args.script)
+        script, text = render(args.script, out)
     except (ScriptError, OSError) as e:
         print(f"choreoc: {e}", file=sys.stderr)
         return 1
 
-    out = args.output
-    if out is None:
-        src_dir = args.script.parent / "src"
-        out = (src_dir if src_dir.is_dir() else args.script.parent) \
-              / "choreo_script.h"
-
-    try:
-        repo = Path(__file__).resolve().parent.parent.parent.parent
-        rel_script = args.script.resolve().relative_to(repo)
-        rel_out = out.resolve().relative_to(repo)
-        regen = f"python3 tapestry/sdk/tools/choreoc.py {rel_script} -o {rel_out}"
-    except ValueError:
-        regen = f"python3 choreoc.py {args.script} -o {out}"
-
-    out.write_text(emit_header(script, args.script.name, regen))
+    out.write_text(text)
     total_s = script.total_timeout_ms / 1000.0
     print(f"choreoc: \"{script.name}\" — {len(script.steps)} step(s), "
           f"total time bound {total_s:g} s → {out}")

--- a/tapestry-os/include/tapestry/bse.h
+++ b/tapestry-os/include/tapestry/bse.h
@@ -180,6 +180,13 @@ typedef struct {
      * the goal point for achieve_hold_ms.  See bse_goal_achieved(). */
     float                      achieve_eps;
     uint32_t                   achieve_hold_ms;
+
+    /* Identity of the L7 goal this intent came from, copied verbatim from
+     * choreo_goal_t::id.  Opaque here: this implementation never reads it.
+     * It is carried so a BSE that queues intents can report which goal a
+     * directive belongs to, and which goal preempted which, without the
+     * intent type having to change later.  0 = anonymous. */
+    uint16_t                   id;
 } tapestry_bse_intent_t;
 
 /* ── Directive: L6 → main loop ────────────────────────────────────────────── */
@@ -227,8 +234,21 @@ void bse_init(element_id_t self_id);
 
 /*
  * bse_submit_intent — Accept a new intent from L7.
- * Replaces any current intent immediately; resets the achievement predicate
- * and any captured HOLD station / EXCHANGE snapshot.
+ *
+ * The submitted intent becomes the active one immediately: the next
+ * bse_tick() decomposes it, and bse_goal_achieved() reports against it.
+ *
+ * What happens to the DISPLACED intent is implementation-defined and must
+ * not be relied on.  This reference implementation discards it — the
+ * achievement predicate and every activation capture (HOLD station,
+ * EXCHANGE snapshot and arc progress, MOVE centroid offset) are reset, so
+ * re-submitting a previously active intent starts it over.  An
+ * implementation that supports a prioritised goal queue may instead
+ * preserve the displaced intent's activation state and resume it when the
+ * preempting intent completes, which is why callers must treat resumption
+ * as neither guaranteed nor forbidden.  See bse_activation_t in bse.c for
+ * exactly which state that covers.
+ *
  * Returns 0 on success, -1 if intent is NULL.
  */
 int bse_submit_intent(const tapestry_bse_intent_t *intent);

--- a/tapestry-os/include/tapestry/transport.h
+++ b/tapestry-os/include/tapestry/transport.h
@@ -42,7 +42,12 @@ int transport_init(void);
 
 /* Update the gossip advertisement / send a UDP broadcast with own_state.
  * qos_tier is one of TAPESTRY_QOS_BEST_EFFORT / SOFT_RT / HARD_RT (wire.h).
- * It is embedded in the gossip frame so peers can prioritize accordingly. */
+ *
+ * RESERVED, NOT YET IMPLEMENTED: the tier is accepted and ignored.  It is
+ * not carried in the gossip wire frame and no receiver acts on it — see
+ * the QoS section of <tapestry/wire.h>, which is authoritative.  Pass
+ * TAPESTRY_QOS_SOFT_RT (what every current call site uses) until transport-
+ * layer prioritization exists. */
 void transport_send(const element_state_t *own_state, uint8_t qos_tier);
 
 /* Drain all pending received gossip frames into wm.  Skips own_id frames.

--- a/tapestry-os/subsys/bse/bse.c
+++ b/tapestry-os/subsys/bse/bse.c
@@ -49,33 +49,55 @@ static element_id_t            s_self_id;
 static tapestry_bse_intent_t   s_intent;
 static tapestry_bse_directive_t s_directive;
 
-/* ── Achievement predicate state ──────────────────────────────────────────── */
+/* ── Per-activation state ─────────────────────────────────────────────────── */
+/*
+ * bse_activation_t — everything an intent accumulates between the moment it
+ * becomes active and the moment it is displaced.  Grouped rather than left
+ * as loose file-scope statics for one reason: this is exactly the state a
+ * preempting BSE has to save and restore.
+ *
+ * This reference implementation holds a single activation and resets it on
+ * every bse_submit_intent(), so a displaced intent is simply forgotten (see
+ * the contract in bse.h — the discard is this implementation's behavior,
+ * not a promise of the interface).  An implementation supporting a
+ * prioritised goal queue keeps a stack of these instead and restores the
+ * preempted entry when the preempting intent completes; nothing outside
+ * this struct needs to be saved for that to work.
+ *
+ * Note what is deliberately NOT here: s_goal_pt / s_goal_pt_valid are
+ * recomputed from scratch by every bse_tick(), so they are tick-scoped, not
+ * activation-scoped, and a resumed intent regenerates them on its first
+ * tick back.
+ */
+typedef struct {
+    /* Feedback controller (achievement predicate) */
+    bool     achieved;
+    uint32_t achieve_accum_ms;
 
-static bool     s_achieved;
-static bool     s_goal_pt_valid;    /* goal point computed this tick        */
+    /* HOLD: own station, captured at activation */
+    bool                hold_captured;
+    tapestry_position_t hold_station;
+
+    /* EXCHANGE: frozen snapshot + arc progress */
+    bool                ex_captured;
+    tapestry_position_t ex_dest;       /* destination station (snapshot) */
+    tapestry_position_t ex_centroid;   /* snapshot centroid              */
+    float               ex_theta0;     /* own start angle about centroid */
+    float               ex_dtheta;     /* total CCW angle to travel      */
+    float               ex_r0;         /* own start radius               */
+    float               ex_r1;         /* destination radius             */
+    float               ex_progress;   /* radians travelled so far       */
+
+    /* MOVE: own offset from the participant centroid, snapshot at activation */
+    bool                move_captured;
+    tapestry_position_t move_offset;   /* own anchor - snapshot centroid */
+} bse_activation_t;
+
+static bse_activation_t s_act;
+
+/* Tick-scoped: recomputed by every bse_tick(), never carried across one. */
+static bool                s_goal_pt_valid;   /* goal point computed this tick */
 static tapestry_position_t s_goal_pt;
-static uint32_t s_achieve_accum_ms;
-
-/* ── HOLD station capture ─────────────────────────────────────────────────── */
-
-static bool                s_hold_captured;
-static tapestry_position_t s_hold_station;
-
-/* ── EXCHANGE snapshot + arc state ───────────────────────────────────────── */
-
-static bool                s_ex_captured;
-static tapestry_position_t s_ex_dest;       /* destination station (snapshot) */
-static tapestry_position_t s_ex_centroid;   /* snapshot centroid              */
-static float               s_ex_theta0;     /* own start angle about centroid */
-static float               s_ex_dtheta;     /* total CCW angle to travel      */
-static float               s_ex_r0;         /* own start radius               */
-static float               s_ex_r1;         /* destination radius             */
-static float               s_ex_progress;   /* radians travelled so far       */
-
-/* ── MOVE offset capture (shape + drift translation) ─────────────────────── */
-
-static bool                s_move_captured;
-static tapestry_position_t s_move_offset;   /* own anchor - snapshot centroid */
 
 /* ── Helpers ──────────────────────────────────────────────────────────────── */
 
@@ -175,20 +197,20 @@ static bool exchange_capture(const world_model_t *wm)
 
     tapestry_position_t own = pos[own_rank];
 
-    s_ex_centroid.x = cx;
-    s_ex_centroid.y = cy;
-    s_ex_dest       = pos[dest];
-    s_ex_theta0     = atan2f(own.y - cy, own.x - cx);
-    s_ex_r0         = sqrtf((own.x - cx) * (own.x - cx)
+    s_act.ex_centroid.x = cx;
+    s_act.ex_centroid.y = cy;
+    s_act.ex_dest       = pos[dest];
+    s_act.ex_theta0     = atan2f(own.y - cy, own.x - cx);
+    s_act.ex_r0         = sqrtf((own.x - cx) * (own.x - cx)
                             + (own.y - cy) * (own.y - cy));
-    s_ex_r1         = sqrtf((s_ex_dest.x - cx) * (s_ex_dest.x - cx)
-                            + (s_ex_dest.y - cy) * (s_ex_dest.y - cy));
+    s_act.ex_r1         = sqrtf((s_act.ex_dest.x - cx) * (s_act.ex_dest.x - cx)
+                            + (s_act.ex_dest.y - cy) * (s_act.ex_dest.y - cy));
 
     /* CCW angular travel to the destination station, in (0, 2π].  All
      * elements rotate the same direction, so pairwise angular offsets —
      * and therefore separation — are preserved throughout the maneuver. */
-    float theta1 = atan2f(s_ex_dest.y - cy, s_ex_dest.x - cx);
-    float dtheta = theta1 - s_ex_theta0;
+    float theta1 = atan2f(s_act.ex_dest.y - cy, s_act.ex_dest.x - cx);
+    float dtheta = theta1 - s_act.ex_theta0;
     while (dtheta <= 0.0f) {
         dtheta += 2.0f * BSE_PI;
     }
@@ -206,29 +228,29 @@ static bool exchange_capture(const world_model_t *wm)
         dtheta = 0.0f;
     }
 
-    s_ex_dtheta   = dtheta;
-    s_ex_progress = 0.0f;
-    s_ex_captured = true;
+    s_act.ex_dtheta   = dtheta;
+    s_act.ex_progress = 0.0f;
+    s_act.ex_captured = true;
     return true;
 }
 
 /* Advance the arc by one tick and return the commanded target. */
 static tapestry_position_t exchange_arc_target(void)
 {
-    s_ex_progress += TAPESTRY_BSE_EXCHANGE_OMEGA_RADPS
+    s_act.ex_progress += TAPESTRY_BSE_EXCHANGE_OMEGA_RADPS
                      * ((float)WM_CYCLE_MS * 0.001f);
 
-    if (s_ex_dtheta <= 0.0f || s_ex_progress >= s_ex_dtheta) {
-        return s_ex_dest;   /* arc complete — exact snapshot station */
+    if (s_act.ex_dtheta <= 0.0f || s_act.ex_progress >= s_act.ex_dtheta) {
+        return s_act.ex_dest;   /* arc complete — exact snapshot station */
     }
 
-    float frac  = s_ex_progress / s_ex_dtheta;
-    float theta = s_ex_theta0 + s_ex_progress;
-    float r     = s_ex_r0 + (s_ex_r1 - s_ex_r0) * frac;
+    float frac  = s_act.ex_progress / s_act.ex_dtheta;
+    float theta = s_act.ex_theta0 + s_act.ex_progress;
+    float r     = s_act.ex_r0 + (s_act.ex_r1 - s_act.ex_r0) * frac;
 
     tapestry_position_t t;
-    t.x = s_ex_centroid.x + r * cosf(theta);
-    t.y = s_ex_centroid.y + r * sinf(theta);
+    t.x = s_act.ex_centroid.x + r * cosf(theta);
+    t.y = s_act.ex_centroid.y + r * sinf(theta);
     return t;
 }
 
@@ -242,12 +264,12 @@ void bse_init(element_id_t self_id)
     s_intent.type    = TAPESTRY_BSE_INTENT_IDLE;
     s_directive.type = TAPESTRY_BSE_DIRECTIVE_IDLE;
 
-    s_achieved         = false;
+    s_act.achieved         = false;
     s_goal_pt_valid    = false;
-    s_achieve_accum_ms = 0;
-    s_hold_captured    = false;
-    s_ex_captured      = false;
-    s_move_captured    = false;
+    s_act.achieve_accum_ms = 0;
+    s_act.hold_captured    = false;
+    s_act.ex_captured      = false;
+    s_act.move_captured    = false;
 }
 
 int bse_submit_intent(const tapestry_bse_intent_t *intent)
@@ -258,12 +280,12 @@ int bse_submit_intent(const tapestry_bse_intent_t *intent)
     s_intent = *intent;
 
     /* New goal — reset captures and the achievement predicate. */
-    s_achieved         = false;
+    s_act.achieved         = false;
     s_goal_pt_valid    = false;
-    s_achieve_accum_ms = 0;
-    s_hold_captured    = false;
-    s_ex_captured      = false;
-    s_move_captured    = false;
+    s_act.achieve_accum_ms = 0;
+    s_act.hold_captured    = false;
+    s_act.ex_captured      = false;
+    s_act.move_captured    = false;
 
     /* An IDLE intent (quiescence) takes effect immediately, not at the next
      * tick — choreo_terminate() submits it and then stops ticking the BSE,
@@ -289,24 +311,24 @@ void bse_tick(const world_model_t *wm, const scr_state_t *scr)
     case TAPESTRY_BSE_INTENT_HOLD: {
         /* Coordinate-free: the station is wherever the element is when the
          * goal activates.  Captured once, then actively station-kept. */
-        if (!s_hold_captured) {
+        if (!s_act.hold_captured) {
             tapestry_position_t own;
             if (!own_position(wm, &own)) {
                 s_directive.type = TAPESTRY_BSE_DIRECTIVE_HOLD;
                 break;
             }
-            s_hold_station  = own;
-            s_hold_captured = true;
+            s_act.hold_station  = own;
+            s_act.hold_captured = true;
         }
         s_directive.type   = TAPESTRY_BSE_DIRECTIVE_MOVE_TO_POINT;
-        s_directive.target = s_hold_station;
-        s_goal_pt          = s_hold_station;
+        s_directive.target = s_act.hold_station;
+        s_goal_pt          = s_act.hold_station;
         s_goal_pt_valid    = true;
         break;
     }
 
     case TAPESTRY_BSE_INTENT_EXCHANGE: {
-        if (!s_ex_captured && !exchange_capture(wm)) {
+        if (!s_act.ex_captured && !exchange_capture(wm)) {
             /* No fresh peer visible — cannot know whose station to take.
              * Hold and retry the capture next tick. */
             s_directive.type = TAPESTRY_BSE_DIRECTIVE_HOLD;
@@ -318,9 +340,9 @@ void bse_tick(const world_model_t *wm, const scr_state_t *scr)
          * once the arc itself has completed — otherwise a body tracking the
          * arc perfectly "achieves" while still up to eps short of the
          * station, and settles offset from it. */
-        s_goal_pt          = s_ex_dest;
-        s_goal_pt_valid    = (s_ex_dtheta <= 0.0f
-                              || s_ex_progress >= s_ex_dtheta);
+        s_goal_pt          = s_act.ex_dest;
+        s_goal_pt_valid    = (s_act.ex_dtheta <= 0.0f
+                              || s_act.ex_progress >= s_act.ex_dtheta);
 
         /* Occupied destination (see the OCCUPIED_M/STANDOFF_M rationale in
          * bse.h): hold a standoff point on the approach line and defer
@@ -343,8 +365,8 @@ void bse_tick(const world_model_t *wm, const scr_state_t *scr)
                 if (!e->is_active || e->is_self || e->is_stale) {
                     continue;
                 }
-                float dx = e->state.position.x - s_ex_dest.x;
-                float dy = e->state.position.y - s_ex_dest.y;
+                float dx = e->state.position.x - s_act.ex_dest.x;
+                float dy = e->state.position.y - s_act.ex_dest.y;
                 if (sqrtf(dx * dx + dy * dy)
                         < TAPESTRY_BSE_EXCHANGE_OCCUPIED_M) {
                     occupied = true;
@@ -354,13 +376,13 @@ void bse_tick(const world_model_t *wm, const scr_state_t *scr)
             if (occupied) {
                 tapestry_position_t own;
                 if (own_position(wm, &own)) {
-                    float dx = own.x - s_ex_dest.x;
-                    float dy = own.y - s_ex_dest.y;
+                    float dx = own.x - s_act.ex_dest.x;
+                    float dy = own.y - s_act.ex_dest.y;
                     float d  = sqrtf(dx * dx + dy * dy);
                     if (d > 1e-3f) {
-                        s_directive.target.x = s_ex_dest.x
+                        s_directive.target.x = s_act.ex_dest.x
                             + dx / d * TAPESTRY_BSE_EXCHANGE_STANDOFF_M;
-                        s_directive.target.y = s_ex_dest.y
+                        s_directive.target.y = s_act.ex_dest.y
                             + dy / d * TAPESTRY_BSE_EXCHANGE_STANDOFF_M;
                     }
                 }
@@ -443,7 +465,7 @@ void bse_tick(const world_model_t *wm, const scr_state_t *scr)
          * element has offset (0,0) — MOVE degenerates to CONVERGE, which
          * is correct: there is no formation to preserve.
          */
-        if (!s_move_captured) {
+        if (!s_act.move_captured) {
             element_id_t        ids[MAX_ELEMENTS];
             tapestry_position_t pos[MAX_ELEMENTS];
             int                 rank;
@@ -459,13 +481,13 @@ void bse_tick(const world_model_t *wm, const scr_state_t *scr)
             }
             cx /= (float)count;
             cy /= (float)count;
-            s_move_offset.x = pos[rank].x - cx;
-            s_move_offset.y = pos[rank].y - cy;
-            s_move_captured = true;
+            s_act.move_offset.x = pos[rank].x - cx;
+            s_act.move_offset.y = pos[rank].y - cy;
+            s_act.move_captured = true;
         }
         s_directive.type     = TAPESTRY_BSE_DIRECTIVE_MOVE_TO_POINT;
-        s_directive.target.x = s_intent.target.x + s_move_offset.x;
-        s_directive.target.y = s_intent.target.y + s_move_offset.y;
+        s_directive.target.x = s_intent.target.x + s_act.move_offset.x;
+        s_directive.target.y = s_intent.target.y + s_act.move_offset.y;
         s_goal_pt             = s_directive.target;
         s_goal_pt_valid       = true;
         break;
@@ -493,9 +515,9 @@ void bse_tick(const world_model_t *wm, const scr_state_t *scr)
 
     /* ── Feedback controller (minimal): achievement predicate ───────────── */
 
-    if (s_intent.type == TAPESTRY_BSE_INTENT_HOLD && s_hold_captured) {
+    if (s_intent.type == TAPESTRY_BSE_INTENT_HOLD && s_act.hold_captured) {
         /* Staying is the goal — trivially achieved; duration governs. */
-        s_achieved = true;
+        s_act.achieved = true;
     } else if (s_goal_pt_valid) {
         float    eps  = s_intent.achieve_eps > 0.0f
                         ? s_intent.achieve_eps
@@ -509,15 +531,15 @@ void bse_tick(const world_model_t *wm, const scr_state_t *scr)
             float dx = own.x - s_goal_pt.x;
             float dy = own.y - s_goal_pt.y;
             if (sqrtf(dx * dx + dy * dy) <= eps) {
-                s_achieve_accum_ms += WM_CYCLE_MS;
+                s_act.achieve_accum_ms += WM_CYCLE_MS;
             } else {
-                s_achieve_accum_ms = 0;
+                s_act.achieve_accum_ms = 0;
             }
-            s_achieved = s_achieve_accum_ms >= hold;
+            s_act.achieved = s_act.achieve_accum_ms >= hold;
         }
     } else {
-        s_achieve_accum_ms = 0;
-        s_achieved         = false;
+        s_act.achieve_accum_ms = 0;
+        s_act.achieved         = false;
     }
 }
 
@@ -528,5 +550,5 @@ const tapestry_bse_directive_t *bse_get_directive(void)
 
 bool bse_goal_achieved(void)
 {
-    return s_achieved;
+    return s_act.achieved;
 }

--- a/tapestry-os/subsys/choreo/choreo.c
+++ b/tapestry-os/subsys/choreo/choreo.c
@@ -85,6 +85,7 @@ static tapestry_bse_intent_t goal_to_intent(const choreo_goal_t *goal)
     intent.direct_path     = goal->direct_path;
     intent.achieve_eps     = goal->achieve_eps;
     intent.achieve_hold_ms = goal->achieve_hold_ms;
+    intent.id              = goal->id;   /* opaque; see choreo_goal_t::id */
     return intent;
 }
 

--- a/tapestry-os/subsys/csm/world_model.c
+++ b/tapestry-os/subsys/csm/world_model.c
@@ -89,6 +89,27 @@ void wm_init(world_model_t *wm,
     wm->owner_id          = owner_id;
     wm->consistency_bias  = consistency_bias;
 
+    /*
+     * entries[] is indexed by element ID directly.  Every peer ID that
+     * arrives over the wire is range-checked before it is used as an index
+     * (wm_receive_gossip, wm_get_entry, wm_reconcile); owner_id is the one
+     * index that comes from the application instead, so it is validated
+     * here — once, where it enters the system — and the owner-indexed call
+     * sites below rely on that.
+     *
+     * An out-of-range owner (a hand-configured element ID, or
+     * ELEMENT_ID_INVALID propagated from a failed identity negotiation)
+     * previously wrote past the end of entries[].  Refuse instead: the
+     * model stays inert — no self entry, no known elements — so callers
+     * degrade to "own position unknown" (L6 holds) rather than corrupting
+     * whatever follows the world model in memory.
+     */
+    if (owner_id >= MAX_ELEMENTS) {
+        wm->owner_id = ELEMENT_ID_INVALID;
+        recompute_metric(wm);
+        return;
+    }
+
     /* Own entry is always authoritative and always active */
     wm_entry_t *self = &wm->entries[owner_id];
     self->state        = *own_state;
@@ -105,6 +126,10 @@ void wm_init(world_model_t *wm,
 
 void wm_update_self(world_model_t *wm, element_state_t *own_state)
 {
+    if (wm->owner_id >= MAX_ELEMENTS) {
+        return;   /* inert model — see the owner_id validation in wm_init */
+    }
+
     wm_entry_t *self = &wm->entries[wm->owner_id];
 
     self->state        = *own_state;
@@ -278,7 +303,12 @@ uint8_t wm_check_collisions(const world_model_t *wm,
                              uint8_t max_events)
 {
     uint8_t count = 0;
-    uint32_t own_clock = wm->entries[wm->owner_id].state.logical_clock;
+    /* Inert model (see wm_init): no self entry to read a clock from, and
+     * the loop below finds no non-self active entries either, so the zero
+     * is never actually stamped onto an event. */
+    uint32_t own_clock = (wm->owner_id < MAX_ELEMENTS)
+                         ? wm->entries[wm->owner_id].state.logical_clock
+                         : 0u;
 
     for (int i = 0; i < MAX_ELEMENTS; i++) {
         if (count >= max_events) {

--- a/tapestry-os/subsys/scr/scr.c
+++ b/tapestry-os/subsys/scr/scr.c
@@ -83,7 +83,19 @@ void scr_tick(scr_state_t *scr, const world_model_t *wm)
      * Self is always included as a candidate in the election but is NOT
      * counted toward fresh_count (which measures external reachability).
      */
-    element_id_t candidates[MAX_ELEMENTS];
+    /*
+     * Sized MAX_ELEMENTS + 1, not MAX_ELEMENTS.  For a well-formed own_id in
+     * [0, MAX_ELEMENTS) — the range csm.h documents — self occupies one of
+     * the MAX_ELEMENTS peer slots, because the loop below skips i == own_id,
+     * so MAX_ELEMENTS entries are exactly enough.  An out-of-range own_id
+     * (API misuse: a hand-configured element ID, or ELEMENT_ID_INVALID
+     * propagated from a failed identity negotiation) skips nothing, and
+     * self + MAX_ELEMENTS peers would write one entry past the end of a
+     * MAX_ELEMENTS array.  The extra slot bounds that to a bad election
+     * rather than a stack smash; such an element is already non-functional,
+     * since the world model indexes entries by ID.
+     */
+    element_id_t candidates[MAX_ELEMENTS + 1];
     uint8_t      n_candidates = 0;
     uint8_t      fresh_count  = 0;
 

--- a/tapestry-os/subsys/transport/transceiver_ble.c
+++ b/tapestry-os/subsys/transport/transceiver_ble.c
@@ -47,11 +47,25 @@ LOG_MODULE_REGISTER(transceiver_ble, LOG_LEVEL_INF);
  * 1 byte (length field) + 1 byte (AD type) + N bytes of data, so the data
  * for our single manufacturer AD record must be ≤ 29 bytes.
  *
- * Budget (no auth): 3 (prefix) + 21 (frame) + 0 (tag) = 24 ≤ 29  ✓
- * Budget (auth):    3 (prefix) + 21 (frame) + 4 (tag) = 28 ≤ 29  ✓ (1 byte
- *                    of margin left — the frame cannot grow again without
- *                    extended advertising or dropping the auth tag)
+ * Budget (no auth): 3 (prefix) + 22 (frame) + 0 (tag) = 25 ≤ 29  ✓
+ * Budget (auth):    3 (prefix) + 22 (frame) + 4 (tag) = 29 ≤ 29  ✓ — EXACTLY
+ *                    at the limit, zero margin.  The gossip frame cannot
+ *                    grow by even one byte while CONFIG_TAPESTRY_WIRE_AUTH_
+ *                    ENABLED is a supported configuration; growing it needs
+ *                    extended advertising, a second AD record, or a shorter
+ *                    auth tag.
+ *
+ * These numbers were hand-maintained and went stale once already: the frame
+ * grew 21 → 22 bytes when the `achieved` field was appended, and nothing
+ * caught it because no build in this repo compiles the auth path.  The
+ * BUILD_ASSERT below is the real guard — it fails the build rather than the
+ * radio if the frame outgrows the record.
  */
+BUILD_ASSERT(MFR_DATA_SIZE <= 29,
+             "Tapestry gossip AD record exceeds the 31-byte BLE advertising "
+             "payload (29 bytes usable after the AD length+type prefix). "
+             "Shrink tapestry_gossip_frame_t, shorten the auth tag, or move "
+             "to extended advertising.");
 
 #define RX_QUEUE_DEPTH  8
 


### PR DESCRIPTION
- webots-formation ran the wrong script: its generated choreo_script.h predated collective achievement (no scope = "all"), and the controller never set goal_achieved before gossiping. Coupled — regenerating the header alone would have made every exchange time out instead of achieving. Fixed together.
- Out-of-range element IDs corrupted memory: wm_init() and wm_update_self() wrote past entries[], wm_check_collisions() read past it, and scr_tick() could overrun candidates[]. owner_id is now validated once in wm_init(); an out-of-range owner leaves the model inert instead.
- transceiver_ble.c's payload budget still assumed a 21-byte frame after the achieved field grew it to 22; the auth config now sits exactly at the 29-byte limit. Corrected, with a BUILD_ASSERT so it cannot go stale again. transport.h's claim that qos_tier is carried on the wire contradicted wire.h and gossip_send(); removed.
- Both flight apps now debounce quorum into a copy rather than writing through the live scr_state_t, which had left scr_get_quorum() disagreeing with the abort machine on 38 of 60 ticks across a flap.
- choreoc gains --check, enforced in CI beside the wire-mirror check. It discovers every generated header and recovers its source from the banner, so an added consumer is covered without editing CI — the drift above happened because a second consumer appeared and nothing tracked it.

Verified: ASan/UBSan over the L4/L5 ID handling and the quorum flap; core compiles warning-free under -Wall -Wextra -Wpedantic; --check rejects the stale header restored from HEAD; wire mirrors, hello_swarm and choreo_sim unchanged.